### PR TITLE
feat: Add SPI support for and update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MicroPython SSD1327
 
-A MicroPython library for SSD1327 128x128 4-bit greyscale OLED displays, over I2C.
+A MicroPython library for SSD1327 128x128 4-bit greyscale OLED displays, over I2C or SPI.
 
 For example, the [Grove - OLED Display 1.12"](http://wiki.seeed.cc/Grove-OLED_Display_1.12inch/) which features a 96x96 display.
 
@@ -18,6 +18,11 @@ $ ampy put ssd1327.py
 
 ```python
 import ssd1327
+
+# using Hardware SPI
+# from machine import Pin, SPI
+# spi = SPI(1, baudrate=10000000, sck=Pin(SCK_PIN), mosi=Pin(MOSI_PIN))
+# display = ssd1327.SSD1327_SPI(128, 128, spi, dc=Pin(DC_PIN), res=Pin(RST_PIN), cs=Pin(CS_PIN))
 
 # using Software I2C
 from machine import SoftI2C, Pin
@@ -51,6 +56,7 @@ See [/examples](/examples) for more.
 * [Raspberry Pi Pico](https://core-electronics.com.au/raspberry-pi-pico.html)
 * [WeMos D1 Mini](https://www.aliexpress.com/item/32529101036.html)
 * [Grove Male Jumper Cable](https://www.seeedstudio.com/Grove-4-pin-Male-Jumper-to-Grove-4-pin-Conversion-Cable-5-PCs-per-Pack.html)
+* [WaveShare 1.5inch OLED Module, SPI/I2C interface](https://www.waveshare.com/1.5inch-oled-module.htm)
 
 ## Connections
 

--- a/ssd1327.py
+++ b/ssd1327.py
@@ -199,3 +199,45 @@ class SEEED_OLED_96X96(SSD1327_I2C):
 class WS_OLED_128X128(SSD1327_I2C):
     def __init__(self, i2c, addr=0x3c):
         super().__init__(128, 128, i2c, addr)
+
+class SSD1327_SPI(SSD1327):
+    def __init__(self, width, height, spi, dc, res=None, cs=None):
+        self.spi = spi
+        self.dc = dc
+        self.res = res
+        self.cs = cs
+        
+        # Initialize pins
+        self.dc.init(self.dc.OUT, value=0)
+        
+        if self.res:
+            self.res.init(self.res.OUT, value=1)
+        
+        if self.cs:
+            self.cs.init(self.cs.OUT, value=1)
+        
+        # Perform hardware reset
+        if self.res:
+            self.res(0)
+            import time
+            time.sleep_ms(10)
+            self.res(1)
+            time.sleep_ms(10)
+        
+        super().__init__(width, height)
+
+    def write_cmd(self, cmd):
+        if self.cs:
+            self.cs(0)
+        self.dc(0)  # Command mode
+        self.spi.write(bytearray([cmd]))
+        if self.cs:
+            self.cs(1)
+
+    def write_data(self, data_buf):
+        if self.cs:
+            self.cs(0)
+        self.dc(1)  # Data mode
+        self.spi.write(data_buf)
+        if self.cs:
+            self.cs(1)


### PR DESCRIPTION
## Summary

Adds SPI interface support for SSD1327 OLED displays

## Implementation

- New SSD1327_SPI class with proper pin handling (DC, RES, CS)
- Hardware reset sequence during initialization
- Optional CS pin support for different display modules

## Testing

Tested the example in readme and [rotating_3d_cube.py](https://github.com/mcauser/micropython-ssd1327/blob/master/examples/rotating_3d_cube.py). BTW, the SPI interface delivers significantly higher animation frame rates.

Tested successfully on:
- [ESP32-S3-ZERO](https://www.waveshare.com/esp32-s3-zero.htm?sku=25517) + [WaveShare 1.5inch OLED Module](https://www.waveshare.com/1.5inch-oled-module.htm)
- Raspberry Pi Pico + WaveShare 1.5inch OLED Module

## Compatibility

Existing I2C implementations remain unchanged.